### PR TITLE
fix: memoize sparkle positions so they don't jump on re-render

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -83,6 +83,17 @@ export default function BirthdayPage() {
 	const nopeAudioRefs = useRef<HTMLAudioElement[]>([]);
 	const yayAudioRef = useRef<HTMLAudioElement | null>(null);
 	const noSoundIndexRef = useRef(0);
+
+	/** Sparkle positions/delays fixed at mount so they don't teleport on re-render when state changes (e.g. No button). */
+	const sparkleStyles = useMemo(
+		() =>
+			Array.from({ length: SPARKLE_COUNT }, () => ({
+				left: `${Math.random() * 100}%`,
+				top: `${Math.random() * 100}%`,
+				animationDelay: `${Math.random() * 2}s`,
+			})),
+		[]
+	);
 
 	useEffect(() => {
 		setIsVisible(true);
@@ -276,19 +287,11 @@ export default function BirthdayPage() {
 				<div className="absolute -bottom-1/2 -right-1/2 w-full h-full bg-gradient-radial from-rose-200/10 via-transparent to-transparent" />
 			</div>
 
-			{/* Floating Sparkles - lazy loaded until hero is visible */}
+			{/* Floating Sparkles - lazy loaded until hero is visible; positions fixed at mount so they don't teleport on re-render */}
 			{isVisible && (
 				<div className="fixed inset-0 pointer-events-none overflow-hidden z-0">
-					{[...Array(SPARKLE_COUNT)].map((_, i) => (
-						<div
-							key={i}
-							className="absolute sparkle"
-							style={{
-								left: `${Math.random() * 100}%`,
-								top: `${Math.random() * 100}%`,
-								animationDelay: `${Math.random() * 2}s`,
-							}}
-						>
+					{sparkleStyles.map((style, i) => (
+						<div key={i} className="absolute sparkle" style={style}>
 							<Sparkles className="w-4 h-4 text-pink-300" />
 						</div>
 					))}


### PR DESCRIPTION
This pull request improves the rendering of floating sparkles in the `BirthdayPage` by ensuring their positions and animation delays are fixed at mount, preventing them from teleporting on re-render. The changes also optimize performance by using `useMemo` to generate sparkle styles only once.

Floating sparkles rendering improvements:

* Added `useMemo` to generate and fix sparkle positions and animation delays at component mount, preventing sparkles from moving unexpectedly when the state changes. (`app/page.tsx`)
* Updated the sparkle rendering logic to use the memoized `sparkleStyles` array instead of generating random positions and delays on each render. (`app/page.tsx`)

Performance optimization:

* Imported `useMemo` in addition to other React hooks to support the memoization of sparkle styles. (`app/page.tsx`)- Use useMemo to compute sparkle positions and animation delays once at mount
- Prevent sparkles from moving when state changes (e.g. No button clicks)
- Avoid recalculating random positions on every re-render
- Add comment explaining why positions are fixed at mount

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely visual/UI stabilization using `useMemo`, with no changes to data handling, routing, or external integrations.
> 
> **Overview**
> Prevents the floating background sparkles on `BirthdayPage` from randomly changing position/animation timing on each state update.
> 
> Sparkle `style` values (left/top/animationDelay) are now generated once via `useMemo` and reused during rendering, with an explanatory comment to document the intent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b60801ff285c8e3ef45b46607df0c5356bd6869. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->